### PR TITLE
[REF] odoo-profiler: Use default pstats print sorting

### DIFF
--- a/profiler/controllers/main.py
+++ b/profiler/controllers/main.py
@@ -101,7 +101,7 @@ class ProfilerController(http.Controller):
             stats_path = os.path.join(dump_dir, '%s.stats' % filename)
             core.profile.dump_stats(stats_path)
             _logger.info("Pstats Command:")
-            params = {'fnames': stats_path, 'sort': 'factor', 'limit': 45,
+            params = {'fnames': stats_path, 'limit': 45,
                       'exclude_fnames': exclude_fname}
             _logger.info(
                 "fnames=%(fnames)s, sort=%(sort)s,"


### PR DESCRIPTION
To full compatibility with current version of pstats_print2list package
Fix https://github.com/Vauxoo/odoo-profiler/issues/41